### PR TITLE
Fix Maven site build

### DIFF
--- a/.github/workflows/maven-verify.yml
+++ b/.github/workflows/maven-verify.yml
@@ -25,3 +25,5 @@ jobs:
   build:
     name: Verify
     uses: apache/maven-gh-actions-shared/.github/workflows/maven-verify.yml@v2
+    with:
+      verify-fail-fast: false

--- a/pom.xml
+++ b/pom.xml
@@ -216,9 +216,13 @@
     <pluginManagement>
       <plugins>
         <plugin>
+          <!-- TODO remove once Maven parent POM will upgraded - MPOM-280 -->
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
           <version>3.3.1</version>
+          <configuration>
+            <detectLinks>false</detectLinks>
+          </configuration>
         </plugin>
       </plugins>
     </pluginManagement>


### PR DESCRIPTION
In this PR I fixed Maven site build. 

Still is failing IT test - `forked-lifecycle` on MacOs jdk 11 and 17 with exception:

```
Caused by: java.lang.NullPointerException
    at org.apache.commons.lang3.SystemUtils.isJavaVersionAtLeast (SystemUtils.java:1626)
    at org.apache.maven.plugins.javadoc.AbstractJavadocMojo.getJavadocExecutable (AbstractJavadocMojo.java:3589)
    at org.apache.maven.plugins.javadoc.AbstractJavadocMojo.executeReport (AbstractJavadocMojo.java:1963)
    at org.apache.maven.plugins.javadoc.JavadocReport.generate (JavadocReport.java:130)
    at org.apache.maven.plugins.site.render.ReportDocumentRenderer.renderDocument (ReportDocumentRenderer.java:239)
    at org.apache.maven.doxia.siterenderer.DefaultSiteRenderer.render (DefaultSiteRenderer.java:349)
    at org.apache.maven.plugins.site.render.SiteMojo.renderLocale (SiteMojo.java:198)
    at org.apache.maven.plugins.site.render.SiteMojo.execute (SiteMojo.java:147)
```

If your dependency updates #7, #8 will not resolve it, I will create issue for it and fix. 